### PR TITLE
v2.2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ assets/js/.DS_Store
 .DS_Store
 /.nova
 .nova/Configuration.json
+CLAUDE.md
+CONTEXT.md
+.claude/
+screenshots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## v2.2.7 (2026-02-15)
+
+### Fixed
+- Fixed grid layouts returning different tributes and ordering compared to FireHawk's default grid. All four grid templates (modern, elegant, gallery, minimal) were sending empty strings for `query`, `startDate`, and `endDate` parameters on initial load, which triggered an unintended fuzzy search in FireHawk's API handler and broke date override logic. Now matches FireHawk's approach of omitting optional parameters when not set. Also stopped spreading unnecessary config properties into the API request.
+
+---
+
 ## v2.2.6 (2026-01-07)
 
 ### Improved

--- a/fcrm-tributes-enhancement-suite.php
+++ b/fcrm-tributes-enhancement-suite.php
@@ -3,7 +3,7 @@
  * Plugin Name: FireHawkCRM Tributes Enhancement Suite
  * Plugin URI: https://github.com/HumanKind-nz/fcrm-tributes-enhancement-suite
  * Description: Performance optimisations and enhancements for the FireHawkCRM Tributes plugin
- * Version: 2.2.6
+ * Version: 2.2.7
  * Author: Weave Digital Studio, Gareth Bissland
  * Author URI: https://weave.co.nz/
  * License: GPL v2 or later
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('FCRM_ENHANCEMENT_SUITE_VERSION', '2.2.6');
+define('FCRM_ENHANCEMENT_SUITE_VERSION', '2.2.7');
 define('FCRM_ENHANCEMENT_SUITE_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FCRM_ENHANCEMENT_SUITE_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FCRM_ENHANCEMENT_SUITE_PLUGIN_FILE', __FILE__);

--- a/templates/layouts/elegant-grid.php
+++ b/templates/layouts/elegant-grid.php
@@ -212,16 +212,31 @@ $container_classes = [
             this.isLoading = true;
             this.showLoading();
             
+            // Build params matching FireHawk's approach: only include optional
+            // fields when they have values. Sending empty strings for query/dates
+            // triggers unintended fuzzy search and breaks date override logic
+            // in FireHawk's get_tribute_search() handler.
+            let params = {
+                size: reset ? this.pageSize : this.loadMoreSize,
+                from: reset ? 0 : this.currentPage * this.loadMoreSize,
+            };
+
+            if (this.searchQuery) params.query = this.searchQuery;
+            if (this.startDate) params.startDate = moment(this.startDate).startOf("day").valueOf();
+            if (this.endDate) params.endDate = moment(this.endDate).endOf("day").valueOf();
+
+            if (this.config.sortByService) params.sortByService = this.config.sortByService;
+            if (this.config.nameFormat) params.nameFormat = this.config.nameFormat;
+            if (this.config.branch) params.branch = this.config.branch;
+            if (this.config.showFutureTributes) params.showFutureTributes = this.config.showFutureTributes;
+            if (this.config.showPastTributes) params.showPastTributes = this.config.showPastTributes;
+            if (this.config.displayServiceInfo) params.displayService = this.config.displayServiceInfo;
+            if (this.config.teamGroupIndex != null) params.teamGroupIndex = this.config.teamGroupIndex;
+            if (this.config.displayBranch) params.displayBranch = this.config.displayBranch;
+
             let data = {
                 action: 'get_tributes',
-                params: {
-                    size: reset ? this.pageSize : this.loadMoreSize,
-                    from: reset ? 0 : this.currentPage * this.loadMoreSize,
-                    query: this.searchQuery || '',
-                    startDate: this.startDate ? moment(this.startDate).startOf("day").valueOf() : '',
-                    endDate: this.endDate ? moment(this.endDate).endOf("day").valueOf() : '',
-                    ...this.config
-                }
+                params: params
             };
             
             console.log('Making AJAX request with data:', data);

--- a/templates/layouts/gallery-grid.php
+++ b/templates/layouts/gallery-grid.php
@@ -214,16 +214,31 @@ $container_classes = [
             this.isLoading = true;
             this.showLoading();
             
+            // Build params matching FireHawk's approach: only include optional
+            // fields when they have values. Sending empty strings for query/dates
+            // triggers unintended fuzzy search and breaks date override logic
+            // in FireHawk's get_tribute_search() handler.
+            let params = {
+                size: reset ? this.pageSize : this.loadMoreSize,
+                from: reset ? 0 : this.currentPage * this.loadMoreSize,
+            };
+
+            if (this.searchQuery) params.query = this.searchQuery;
+            if (this.startDate) params.startDate = moment(this.startDate).startOf("day").valueOf();
+            if (this.endDate) params.endDate = moment(this.endDate).endOf("day").valueOf();
+
+            if (this.config.sortByService) params.sortByService = this.config.sortByService;
+            if (this.config.nameFormat) params.nameFormat = this.config.nameFormat;
+            if (this.config.branch) params.branch = this.config.branch;
+            if (this.config.showFutureTributes) params.showFutureTributes = this.config.showFutureTributes;
+            if (this.config.showPastTributes) params.showPastTributes = this.config.showPastTributes;
+            if (this.config.displayServiceInfo) params.displayService = this.config.displayServiceInfo;
+            if (this.config.teamGroupIndex != null) params.teamGroupIndex = this.config.teamGroupIndex;
+            if (this.config.displayBranch) params.displayBranch = this.config.displayBranch;
+
             let data = {
                 action: 'get_tributes',
-                params: {
-                    size: reset ? this.pageSize : this.loadMoreSize,
-                    from: reset ? 0 : this.currentPage * this.loadMoreSize,
-                    query: this.searchQuery || '',
-                    startDate: this.startDate ? moment(this.startDate).startOf("day").valueOf() : '',
-                    endDate: this.endDate ? moment(this.endDate).endOf("day").valueOf() : '',
-                    ...this.config
-                }
+                params: params
             };
             
             console.log('Making AJAX request with data:', data);

--- a/templates/layouts/minimal.php
+++ b/templates/layouts/minimal.php
@@ -216,30 +216,31 @@ jQuery(document).ready(function($) {
         
         console.log('Loading tributes with search:', search);
         
+        // Build params matching FireHawk's approach: only include optional
+        // fields when they have values. Sending empty strings for query/dates
+        // triggers unintended fuzzy search and breaks date override logic
+        // in FireHawk's get_tribute_search() handler.
+        const ajaxParams = {
+            size: <?php echo intval($atts['size']); ?>,
+            from: (page - 1) * <?php echo intval($atts['size']); ?>,
+        };
+
+        if (search.name) ajaxParams.query = search.name;
+        if (search.date_from) ajaxParams.startDate = moment(search.date_from).startOf("day").valueOf();
+        if (search.date_to) ajaxParams.endDate = moment(search.date_to).endOf("day").valueOf();
+
+        <?php if ($sortByService): ?>ajaxParams.sortByService = true;<?php endif; ?>
+        <?php if ($nameFormat): ?>ajaxParams.nameFormat = <?php echo json_encode($nameFormat); ?>;<?php endif; ?>
+        <?php if ($branch): ?>ajaxParams.branch = <?php echo json_encode($branch); ?>;<?php endif; ?>
+        <?php if ($showFutureTributes): ?>ajaxParams.showFutureTributes = true;<?php endif; ?>
+        <?php if ($showPastTributes): ?>ajaxParams.showPastTributes = true;<?php endif; ?>
+        <?php if ($displayServiceInfo): ?>ajaxParams.displayService = true;<?php endif; ?>
+        <?php if ($teamGroupIndex !== null): ?>ajaxParams.teamGroupIndex = <?php echo json_encode($teamGroupIndex); ?>;<?php endif; ?>
+        <?php if ($displayBranch): ?>ajaxParams.displayBranch = true;<?php endif; ?>
+
         const ajaxData = {
             action: 'get_tributes',
-            params: {
-                size: <?php echo intval($atts['size']); ?>,
-                from: (page - 1) * <?php echo intval($atts['size']); ?>,
-                query: search.name || '',
-                startDate: search.date_from ? moment(search.date_from).startOf("day").valueOf() : '',
-                endDate: search.date_to ? moment(search.date_to).endOf("day").valueOf() : '',
-                // Include same configuration as modern grid
-                sortByService: <?php echo json_encode($sortByService); ?>,
-                team: <?php echo json_encode($team); ?>,
-                dateLocale: <?php echo json_encode($dateLocale); ?>,
-                nameFormat: <?php echo json_encode($nameFormat); ?>,
-                dateFormat: <?php echo json_encode($dateFormat); ?>,
-                filterDateFormat: <?php echo json_encode($filterDateFormat); ?>,
-                showFutureTributes: <?php echo json_encode($showFutureTributes); ?>,
-                showPastTributes: <?php echo json_encode($showPastTributes); ?>,
-                branch: <?php echo json_encode($branch); ?>,
-                displayBranch: <?php echo json_encode($displayBranch); ?>,
-                displayServiceInfo: <?php echo json_encode($displayServiceInfo); ?>,
-                hideDateOfBirth: <?php echo json_encode($hideDateOfBirth); ?>,
-                teamGroupIndex: <?php echo json_encode($teamGroupIndex); ?>,
-                defaultImageUrl: <?php echo json_encode($fcrmDefaultImageUrl); ?>
-            }
+            params: ajaxParams
         };
         
         console.log('Making AJAX request with data:', ajaxData);

--- a/templates/layouts/modern-grid.php
+++ b/templates/layouts/modern-grid.php
@@ -212,16 +212,33 @@ $container_classes = [
             this.isLoading = true;
             this.showLoading();
             
+            // Build params matching FireHawk's approach: only include optional
+            // fields when they have values. Sending empty strings for query/dates
+            // triggers unintended fuzzy search and breaks date override logic
+            // in FireHawk's get_tribute_search() handler.
+            let params = {
+                size: resetPage ? this.pageSize : this.loadMoreSize,
+                from: resetPage ? 0 : this.currentPage * this.loadMoreSize,
+            };
+
+            // Only include search/date params when they have values
+            if (this.searchQuery) params.query = this.searchQuery;
+            if (this.startDate) params.startDate = moment(this.startDate).startOf("day").valueOf();
+            if (this.endDate) params.endDate = moment(this.endDate).endOf("day").valueOf();
+
+            // Only include config properties that FireHawk's handler reads
+            if (this.config.sortByService) params.sortByService = this.config.sortByService;
+            if (this.config.nameFormat) params.nameFormat = this.config.nameFormat;
+            if (this.config.branch) params.branch = this.config.branch;
+            if (this.config.showFutureTributes) params.showFutureTributes = this.config.showFutureTributes;
+            if (this.config.showPastTributes) params.showPastTributes = this.config.showPastTributes;
+            if (this.config.displayServiceInfo) params.displayService = this.config.displayServiceInfo;
+            if (this.config.teamGroupIndex != null) params.teamGroupIndex = this.config.teamGroupIndex;
+            if (this.config.displayBranch) params.displayBranch = this.config.displayBranch;
+
             let data = {
                 action: 'get_tributes',
-                params: {
-                    size: resetPage ? this.pageSize : this.loadMoreSize,
-                    from: resetPage ? 0 : this.currentPage * this.loadMoreSize,
-                    query: this.searchQuery || '',
-                    startDate: this.startDate ? moment(this.startDate).startOf("day").valueOf() : '',
-                    endDate: this.endDate ? moment(this.endDate).endOf("day").valueOf() : '',
-                    ...this.config
-                }
+                params: params
             };
             
             console.log('Making AJAX request with data:', data);


### PR DESCRIPTION
Fix grid layouts sending empty strings for query/date params to FireHawk API, which triggered unintended fuzzy search and broke tribute ordering. All four grid templates now match FireHawk's approach of omitting optional parameters.